### PR TITLE
Add support for setting the ENA flags on registration.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -69,17 +69,6 @@ static PACKAGES: &[&str] = &[
     "acorn-dynamic-import",
 ];
 
-static COMMANDS: &[&str] = &[
-    "cmake .",
-    "make",
-    "make clean",
-    "gcc foo.c -o foo",
-    "gcc bar.c -o bar",
-    "./helper.sh rebuild-cache",
-    "make all-clean",
-    "make test",
-];
-
 static LOOKING_GLASS: console::Emoji<'_, '_> = console::Emoji("🔍  ", "");
 static TRUCK: console::Emoji<'_, '_> = console::Emoji("🚚  ", "");
 static CLIP: console::Emoji<'_, '_> = console::Emoji("🔗  ", "");

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -84,6 +84,7 @@ pub async fn ec2_register_image(
     client: &Ec2Client,
     snapshot_id: &SnapshotId,
     image_name: &str,
+    image_ena: &bool,
 ) -> ImageId {
     let block_device_mappings = rusoto_ec2::BlockDeviceMapping{
         device_name: Some(String::from("/dev/sda1")),
@@ -102,6 +103,7 @@ pub async fn ec2_register_image(
             block_device_mappings
         ]),
         name: image_name.to_owned(),
+        ena_support: Some(image_ena.to_owned()),
         ..Default::default()
     };
     return client.register_image(request)


### PR DESCRIPTION
Resolves #1.  I also removed a static commands struct that seemed to be completely unrelated to anything ami-uploader does.

I've tested this and it does in fact set the AMI EnaSupport flag.